### PR TITLE
fix(lib): add use client directive to context

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "prettier": "^3.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "rollup-preserve-directives": "^1.1.3",
     "tsx": "^4.19.4",
     "typescript": "^5.8.3",
     "vite": "^6.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      rollup-preserve-directives:
+        specifier: ^1.1.3
+        version: 1.1.3(rollup@4.40.2)
       tsx:
         specifier: ^4.19.4
         version: 4.19.4
@@ -1241,6 +1244,11 @@ packages:
     resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
     engines: {node: '>= 0.4'}
     hasBin: true
+
+  rollup-preserve-directives@1.1.3:
+    resolution: {integrity: sha512-oXqxd6ZzkoQej8Qt0k+S/yvO2+S4CEVEVv2g85oL15o0cjAKTKEuo2MzyA8FcsBBXbtytBzBMFAbhvQg4YyPUQ==}
+    peerDependencies:
+      rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
 
   rollup@4.40.2:
     resolution: {integrity: sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==}
@@ -2742,6 +2750,11 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rollup-preserve-directives@1.1.3(rollup@4.40.2):
+    dependencies:
+      magic-string: 0.30.17
+      rollup: 4.40.2
 
   rollup@4.40.2:
     dependencies:

--- a/src/lib/IconBase.tsx
+++ b/src/lib/IconBase.tsx
@@ -1,5 +1,6 @@
-import * as React from "react";
+"use client";
 import type { ReactElement } from "react";
+import * as React from "react";
 import { IconContext } from "./context";
 import { IconProps, IconWeight } from "./types";
 

--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -1,3 +1,4 @@
+"use client";
 import { createContext } from "react";
 import type { IconProps } from "./types";
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,12 @@
-import { resolve } from "path";
-import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { resolve } from "path";
+import preserveDirectives from "rollup-preserve-directives";
 import dts from "vite-plugin-dts";
+import { defineConfig } from "vitest/config";
 import pkg from "./package.json";
 
 export default defineConfig({
-  plugins: [react({ jsxRuntime: "classic" }), dts()],
+  plugins: [react({ jsxRuntime: "classic" }), preserveDirectives(), dts()],
   build: {
     target: "ES2018",
     lib: {


### PR DESCRIPTION
This allows for client side icons to be used in app router. 

Added the preserve directives plugin for vite. We use it since last year in our packages and it works great.

Added `"use client";` to the context files otherwise they will fail when used in app router.

We understand using the ssr version is preferable though.